### PR TITLE
PR- 7 LOADING STATE AND SUSPENSE / GET ITEMS SERVICE REFACTOR

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import {  Archivo } from "next/font/google";
+import {  Archivo,  } from "next/font/google";
 import "./globals.css";
 import Header from "@/components/layout/header/Header";
 import Footer from "@/components/layout/Footer";

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,8 +1,0 @@
-export default function Loading() {
-    
-    return (
-        <div className="flex flex-col text-center items-center justify-center w-full h-full min-h-screen animate-pulse p-4 border rounded-lg shadow-md bg-white">
-          Loading...
-      </div>
-    )
-  }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 import Catalog from "@/components/catalog/Catalog";
-import Loading from "@/app/loading";
-import { getItems } from "@/services/items-service";
+import Loading from "@/components/catalog/loading";
 import { Suspense } from "react";
+
 
 
 export default async function Home({
@@ -13,21 +13,17 @@ export default async function Home({
 const genre = (await (searchParams)).genre
 const page = (await (searchParams)).page
 
-  
-  const data = await getItems({ genre: genre, page: page });
-
-  const games = data.games
-  const categories = data.availableFilters || ['']
-
-  
 
   return (
     <main className='flex min-h-screen flex-col items-center justify-between'>
-      <Suspense fallback={<Loading />}>
+      
       <div className="w-full px-6 lg:px-32">
-        <Catalog filters={categories} games={games}></Catalog>
+        <Suspense key={genre} fallback={<Loading></Loading>}>
+        <Catalog page={page} genre={genre}></Catalog>
+        </Suspense>
+        
       </div>
-      </Suspense>
+    
       
     </main>
   )

--- a/src/components/catalog/Catalog.tsx
+++ b/src/components/catalog/Catalog.tsx
@@ -1,31 +1,40 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import Container from './Container';
 import CatalogItem from './CatalogItem';
 import GenreSection from './GenreSection';
+
+import { getItems } from '@/services/items-service';
 import { Game } from '@/utils/endpoint';
 
 
+
 interface CatalogProps{
-  games: Game[] | null;
-  filters: string[]
+  genre: string | undefined;
+  page: string | undefined;
 }
-const Catalog: React.FC<CatalogProps> = ({games, filters}) => {
+const Catalog: React.FC<CatalogProps> = async({genre, page}) => {
+
+  
+  const data = await getItems({ genre: genre, page: page });
+
+  const games = data.games
+  const categories = data.availableFilters || ['']
     return (
+  
         <div className='w-full'>
-        <GenreSection filters={filters}/>
-        <div className='py-7'>
-         
+        <GenreSection filters={categories}/>
+        <div className='py-7'>    
           <Container>
-          {games && games.map((item) => (
+          {games && games.map((item: Game) => (
             <CatalogItem description={item.description} genre={item.genre} id={item.id} image={item.image} isNew={item.isNew} name={item.name} price={item.price} key={item.id}/>
           ))}
-  
         </Container>
-        
-        
+      
         </div>
-        
+
         </div>
+
+        
     );
 };
 

--- a/src/components/catalog/CatalogItem.tsx
+++ b/src/components/catalog/CatalogItem.tsx
@@ -4,6 +4,7 @@ import Button from '../common/Button';
 import { Game } from '@/utils/endpoint';
 
 
+
 const NewBadge = () =>{
     return( <div className='absolute left-3 top-3 px-3 py-2 rounded-md text-md bg-[#F5F5F4]'>
         New
@@ -11,7 +12,8 @@ const NewBadge = () =>{
 }
 const CatalogItem: React.FC<Game> = ({ id, genre, name, price, image, isNew }) => {
     return (
-        <div className="w-full flex flex-col gap-5 max-w-96  p-6 rounded-2xl border border-0.5 border-accent-gray " key={id}>
+    
+            <div className="w-full flex flex-col gap-5 max-w-96  p-6 rounded-2xl border border-0.5 border-accent-gray " key={id}>
             <div className='relative rounded-t-2xl h-60'>
                 {isNew && <NewBadge/>}
             <img src={image} alt={name} className=" w-full h-full object-cover rounded-t-2xl" />
@@ -27,6 +29,8 @@ const CatalogItem: React.FC<Game> = ({ id, genre, name, price, image, isNew }) =
             </div>
             <Button type="outline" onClick={()=>{}} label='ADD TO CART'></Button>
         </div>
+
+        
     );
 };
 

--- a/src/components/catalog/CatalogItemSkeleton.tsx
+++ b/src/components/catalog/CatalogItemSkeleton.tsx
@@ -1,0 +1,23 @@
+export const CatalogItemSkeleton =() =>{
+    return (
+        <div className="w-full flex flex-col gap-5 animate-pulse bg-main-gray/80 max-w-96 p-6 rounded-2xl">
+   
+              <div className="relative rounded-t-2xl h-60 "></div>
+              
+        
+              <div className="w-full flex flex-col gap-3">
+        
+                <div className="h-5 w-32 bg-gray-200 animate-pulse rounded"></div>
+                
+            
+                <div className="flex justify-between items-center">
+                  <div className="h-6 w-48 bg-gray-200 animate-pulse rounded"></div>
+                  <div className="h-6 w-16 bg-gray-200 animate-pulse rounded"></div>
+                </div>
+                
+           
+                <div className="h-10 w-full bg-gray-200 animate-pulse rounded"></div>
+              </div>
+            </div>
+    )
+}

--- a/src/components/catalog/GenreSelector.tsx
+++ b/src/components/catalog/GenreSelector.tsx
@@ -12,24 +12,23 @@ const GenreSelector: React.FC<GenreSelectorProps> = ({filters}) => {
 
    const selectedGenre = searchParams.get('genre')  || 'All' ;
 
-
    const handleChange = (event: { target: { value: any; }; }) => {
-    debugger
+
     const newGenre = event.target.value;
 
-    const params = new URLSearchParams(searchParams.toString());
     if (newGenre && newGenre != 'All') {
-      params.set('genre', newGenre);
+      
+      router.push(`/?genre=${newGenre}&page=1`)
     } else {
-      params.delete('genre');
+      router.push('/');
     }
-    router.push(`?${params.toString()}`);
   };
    
 
 
     return (
         <div className='w-full  flex justify-start md:justify-end'>
+        
             <div className='flex'>
             <span className='text-md font-bold select-none'>Genre</span>
             <div className='w-px bg-accent-black h-full mx-3'></div>

--- a/src/components/catalog/loading.tsx
+++ b/src/components/catalog/loading.tsx
@@ -1,0 +1,15 @@
+import { CatalogItemSkeleton } from "./CatalogItemSkeleton"
+
+export default function Loading() {
+    
+    return (
+        <div className="flex flex-col text-center items-center justify-center w-full h-full min-h-screen p-4 ">
+          <div className="h-24 w-full flex justify-center items-center animate-pulse text-center text-2xl"> Loading...</div>
+          <div className=" w-full grid grid-cols-[repeat(auto-fill,minmax(327px,1fr))] place-items-center gap-12">
+          {Array.from({length:8}).map((skeleton, id) => {
+            return(<CatalogItemSkeleton key={id}/>)
+          })}
+        </div>
+      </div>
+    )
+  }

--- a/src/services/items-service.tsx
+++ b/src/services/items-service.tsx
@@ -5,6 +5,7 @@ interface GetItemsProps {
 
 const getItems = async({genre = null, page = '1'}: GetItemsProps)=>{
 
+   try{
     const params = new URLSearchParams();
     if(genre){
         params.append('genre', genre)
@@ -14,12 +15,25 @@ const getItems = async({genre = null, page = '1'}: GetItemsProps)=>{
     }
     const url = `${process.env.API_BASE_URL}/api/games?${params.toString()}`;
     
-    const data = await fetch(url, {
+    const response = await fetch(url, {
         method: 'GET',
         cache: "no-cache"
     })
 
-    return data.json()
+
+    if (!response.ok) {
+        throw new Error(`Error fetching games: ${response.statusText}`);
+    }
+    
+    return await response.json()
+    
+   }
+   catch(e){
+    console.error('Error getting games data',e)
+   }
+
+
+    
 }
 
 export {getItems}


### PR DESCRIPTION
The app only showed loading state at the first render and seem to get 'stuck' when the params switched even if in the background the fetching was being properly done, so some refactors and changes where made to fix this bug.

Fetching is now inside the catalog component instead of main page and the suspense surrounds it to display on every fetch and not only the first one. 
New skeletons exist and are displayed into the components/catalog path.
Small refactor to GetItems service to handle better requests that aren't ok.

**OLD:**
https://www.loom.com/share/280fb56dcc3e4c82b723e175a76637ae

**NEW:**
https://www.loom.com/share/3e8b00e3cab84f4cb475e86ceaa833aa