### PR TITLE
HOTFIX DEPLOY: PASS GAME AS SINGLE ITEM (UNSAVED FILE)

### DIFF
--- a/src/components/catalog/Catalog.tsx
+++ b/src/components/catalog/Catalog.tsx
@@ -25,7 +25,7 @@ const Catalog: React.FC<CatalogProps> = async({genre, page}) => {
         <GenreSection filters={categories}/>
         <div className='py-7'>    
           <Container>
-          {games.length > 0 && games.map((item: Game) => (
+          {games && games.map((item: Game) => (
             <CatalogItem game={item} key={item.id}/>
           ))}
         </Container>

--- a/src/components/catalog/Catalog.tsx
+++ b/src/components/catalog/Catalog.tsx
@@ -25,8 +25,8 @@ const Catalog: React.FC<CatalogProps> = async({genre, page}) => {
         <GenreSection filters={categories}/>
         <div className='py-7'>    
           <Container>
-          {games && games.map((item: Game) => (
-            <CatalogItem description={item.description} genre={item.genre} id={item.id} image={item.image} isNew={item.isNew} name={item.name} price={item.price} key={item.id}/>
+          {games.length > 0 && games.map((item: Game) => (
+            <CatalogItem game={item} key={item.id}/>
           ))}
         </Container>
       


### PR DESCRIPTION
The previous PR didnt include this fule because it wasn't saved properly and this is necessary to receive the props in the correct way and prevent the app from crashing.